### PR TITLE
ツイート時に挿入されるURLが常に fgosccalc.appspot.com になるようにする。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ deploy: pre-deploy app-deploy-staging post-deploy
 deploy-prod: pre-deploy app-deploy-production post-deploy
 
 app-deploy-staging:
-	gcloud app deploy --no-promote
+	gcloud app deploy --no-promote -v stg
 
 app-deploy-production:
 	gcloud app deploy

--- a/static/js/src/report.jsx
+++ b/static/js/src/report.jsx
@@ -23,6 +23,7 @@ window.twttr = (function(d, s, id) {
 }(document, "script", "twitter-wjs"));
 
 const defaultQuestName = '(クエスト名)'
+const tweetURL = 'https://fgosccalc.appspot.com'
 
 class TableLine extends React.Component {
   constructor(props) {
@@ -448,7 +449,7 @@ class TweetButton extends React.Component {
       }
       console.log('createShareButton run')
       window.twttr.widgets.createShareButton(
-        '',
+        tweetURL,
         el,
         {
           text: this.props.reportText,

--- a/static/js/src/report.jsx
+++ b/static/js/src/report.jsx
@@ -1,5 +1,5 @@
 "use strict";
-// ver 20200729-01
+// ver 20200801-01
 Sentry.init({
   dsn: "https://c3ee02d195ae440aacd020b5869abfa7@o425638.ingest.sentry.io/5363673",
 });


### PR DESCRIPTION
現在の設定では、ベータサイトURLであっても実体は本番サイトになっている。そこで、ツイートボタンによるツイートのときに強制挿入されるURLが本番サイトのものであれば、実質的に本番サイトを利用しているのと同じことになる。この修正でそれを達成する。