### PR TITLE
未復刻イベント対応と礼装が周回前後未ドロップの時の挙動変更

### DIFF
--- a/data/json/cbc2019.json
+++ b/data/json/cbc2019.json
@@ -1,0 +1,366 @@
+[
+    {
+        "id": 94034620,
+        "name": "カクテルテイスティング 初級",
+        "place": "",
+        "chapter": "",
+        "qp": 1900,
+        "drop": [
+            {
+                "id": 6510,
+                "name": "無間の歯車",
+                "type": "Item",
+                "dropPriority": 8302
+            },
+            {
+                "id": 6106,
+                "name": "殺の魔石",
+                "type": "Item",
+                "dropPriority": 6195
+            },
+            {
+                "id": 6006,
+                "name": "殺の輝石",
+                "type": "Item",
+                "dropPriority": 6095
+            },
+            {
+                "id": 7006,
+                "name": "アサシンピース",
+                "type": "Item",
+                "dropPriority": 5195
+            },
+            {
+                "id": 94034602,
+                "name": "トリッキークロス",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94034601,
+                "name": "バッドコースター",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "カクテルテイスティング 初級"
+    },
+    {
+        "id": 94034621,
+        "name": "カクテルテイスティング 中級",
+        "place": "",
+        "chapter": "",
+        "qp": 2900,
+        "drop": [
+            {
+                "id": 6502,
+                "name": "世界樹の種",
+                "type": "Item",
+                "dropPriority": 8203
+            },
+            {
+                "id": 6534,
+                "name": "励振火薬",
+                "type": "Item",
+                "dropPriority": 8105
+            },
+            {
+                "id": 6004,
+                "name": "騎の輝石",
+                "type": "Item",
+                "dropPriority": 6097
+            },
+            {
+                "id": 7004,
+                "name": "ライダーピース",
+                "type": "Item",
+                "dropPriority": 5197
+            },
+            {
+                "id": 94034603,
+                "name": "ハーミットシェーカー",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94034602,
+                "name": "トリッキークロス",
+                "type": "Item",
+                "dropPriority": 2002
+            }
+        ],
+        "shortname": "カクテルテイスティング 中級"
+    },
+    {
+        "id": 94034622,
+        "name": "カクテルテイスティング 上級",
+        "place": "",
+        "chapter": "",
+        "qp": 4400,
+        "drop": [
+            {
+                "id": 6514,
+                "name": "ホムンクルスベビー",
+                "type": "Item",
+                "dropPriority": 8304
+            },
+            {
+                "id": 6516,
+                "name": "凶骨",
+                "type": "Item",
+                "dropPriority": 8101
+            },
+            {
+                "id": 6103,
+                "name": "槍の魔石",
+                "type": "Item",
+                "dropPriority": 6198
+            },
+            {
+                "id": 6003,
+                "name": "槍の輝石",
+                "type": "Item",
+                "dropPriority": 6098
+            },
+            {
+                "id": 7003,
+                "name": "ランサーピース",
+                "type": "Item",
+                "dropPriority": 5198
+            },
+            {
+                "id": 94034603,
+                "name": "ハーミットシェーカー",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94034601,
+                "name": "バッドコースター",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "カクテルテイスティング 上級"
+    },
+    {
+        "id": 94034623,
+        "name": "カクテルテイスティング ミルク級",
+        "place": "",
+        "chapter": "",
+        "qp": 6400,
+        "drop": [
+            {
+                "id": 6528,
+                "name": "原初の産毛",
+                "type": "Item",
+                "dropPriority": 8405
+            },
+            {
+                "id": 6503,
+                "name": "英雄の証",
+                "type": "Item",
+                "dropPriority": 8100
+            },
+            {
+                "id": 6107,
+                "name": "狂の魔石",
+                "type": "Item",
+                "dropPriority": 6194
+            },
+            {
+                "id": 6007,
+                "name": "狂の輝石",
+                "type": "Item",
+                "dropPriority": 6094
+            },
+            {
+                "id": 7107,
+                "name": "バーサーカーモニュメント",
+                "type": "Item",
+                "dropPriority": 5294
+            },
+            {
+                "id": 94034602,
+                "name": "トリッキークロス",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94034601,
+                "name": "バッドコースター",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "ミルク級"
+    },
+    {
+        "id": 94034624,
+        "name": "カクテルテイスティング ソーダ級",
+        "place": "",
+        "chapter": "",
+        "qp": 7400,
+        "drop": [
+            {
+                "id": 6521,
+                "name": "黒獣脂",
+                "type": "Item",
+                "dropPriority": 8403
+            },
+            {
+                "id": 6530,
+                "name": "魔術髄液",
+                "type": "Item",
+                "dropPriority": 8103
+            },
+            {
+                "id": 6105,
+                "name": "術の魔石",
+                "type": "Item",
+                "dropPriority": 6196
+            },
+            {
+                "id": 6005,
+                "name": "術の輝石",
+                "type": "Item",
+                "dropPriority": 6096
+            },
+            {
+                "id": 7105,
+                "name": "キャスターモニュメント",
+                "type": "Item",
+                "dropPriority": 5296
+            },
+            {
+                "id": 94034603,
+                "name": "ハーミットシェーカー",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94034602,
+                "name": "トリッキークロス",
+                "type": "Item",
+                "dropPriority": 2002
+            }
+        ],
+        "shortname": "ソーダ級"
+    },
+    {
+        "id": 94034625,
+        "name": "カクテルテイスティング ロック級",
+        "place": "",
+        "chapter": "",
+        "qp": 8400,
+        "drop": [
+            {
+                "id": 6531,
+                "name": "奇奇神酒",
+                "type": "Item",
+                "dropPriority": 8505
+            },
+            {
+                "id": 6513,
+                "name": "隕蹄鉄",
+                "type": "Item",
+                "dropPriority": 8305
+            },
+            {
+                "id": 6202,
+                "name": "弓の秘石",
+                "type": "Item",
+                "dropPriority": 6299
+            },
+            {
+                "id": 6102,
+                "name": "弓の魔石",
+                "type": "Item",
+                "dropPriority": 6199
+            },
+            {
+                "id": 6002,
+                "name": "弓の輝石",
+                "type": "Item",
+                "dropPriority": 6099
+            },
+            {
+                "id": 7102,
+                "name": "アーチャーモニュメント",
+                "type": "Item",
+                "dropPriority": 5299
+            },
+            {
+                "id": 94034603,
+                "name": "ハーミットシェーカー",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94034601,
+                "name": "バッドコースター",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "ロック級"
+    },
+    {
+        "id": 94034626,
+        "name": "カクテルテイスティング ストレート級",
+        "place": "",
+        "chapter": "",
+        "qp": 9400,
+        "drop": [
+            {
+                "id": 6525,
+                "name": "智慧のスカラベ",
+                "type": "Item",
+                "dropPriority": 8503
+            },
+            {
+                "id": 6512,
+                "name": "竜の牙",
+                "type": "Item",
+                "dropPriority": 8200
+            },
+            {
+                "id": 6201,
+                "name": "剣の秘石",
+                "type": "Item",
+                "dropPriority": 6300
+            },
+            {
+                "id": 6001,
+                "name": "剣の輝石",
+                "type": "Item",
+                "dropPriority": 6100
+            },
+            {
+                "id": 7101,
+                "name": "セイバーモニュメント",
+                "type": "Item",
+                "dropPriority": 5300
+            },
+            {
+                "id": 94034603,
+                "name": "ハーミットシェーカー",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94034602,
+                "name": "トリッキークロス",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94034601,
+                "name": "バッドコースター",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "ストレート級"
+    }
+]

--- a/data/json/cbc2020.json
+++ b/data/json/cbc2020.json
@@ -1,0 +1,412 @@
+[
+    {
+        "id": 94046601,
+        "name": "大魔女の食材集め 初級",
+        "place": "",
+        "chapter": "",
+        "qp": 1900,
+        "drop": [
+            {
+                "id": 6526,
+                "name": "追憶の貝殻",
+                "type": "Item",
+                "dropPriority": 8308
+            },
+            {
+                "id": 6004,
+                "name": "騎の輝石",
+                "type": "Item",
+                "dropPriority": 6097
+            },
+            {
+                "id": 7004,
+                "name": "ライダーピース",
+                "type": "Item",
+                "dropPriority": 5197
+            },
+            {
+                "id": 94046502,
+                "name": "不気味な薬草",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94046501,
+                "name": "怪しい麦袋",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "大魔女の食材集め 初級"
+    },
+    {
+        "id": 94046602,
+        "name": "大魔女の食材集め 中級",
+        "place": "",
+        "chapter": "",
+        "qp": 2900,
+        "drop": [
+            {
+                "id": 6512,
+                "name": "竜の牙",
+                "type": "Item",
+                "dropPriority": 8200
+            },
+            {
+                "id": 6003,
+                "name": "槍の輝石",
+                "type": "Item",
+                "dropPriority": 6098
+            },
+            {
+                "id": 7003,
+                "name": "ランサーピース",
+                "type": "Item",
+                "dropPriority": 5198
+            },
+            {
+                "id": 94046503,
+                "name": "疑惑のハチミツ",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94046502,
+                "name": "不気味な薬草",
+                "type": "Item",
+                "dropPriority": 2002
+            }
+        ],
+        "shortname": "大魔女の食材集め 中級"
+    },
+    {
+        "id": 94046603,
+        "name": "大魔女の食材集め 上級",
+        "place": "",
+        "chapter": "",
+        "qp": 4400,
+        "drop": [
+            {
+                "id": 6509,
+                "name": "蛇の宝玉",
+                "type": "Item",
+                "dropPriority": 8307
+            },
+            {
+                "id": 6005,
+                "name": "術の輝石",
+                "type": "Item",
+                "dropPriority": 6096
+            },
+            {
+                "id": 7005,
+                "name": "キャスターピース",
+                "type": "Item",
+                "dropPriority": 5196
+            },
+            {
+                "id": 94046503,
+                "name": "疑惑のハチミツ",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94046501,
+                "name": "怪しい麦袋",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "大魔女の食材集め 上級"
+    },
+    {
+        "id": 94046604,
+        "name": "大魔女の食材集め 味見級",
+        "place": "",
+        "chapter": "",
+        "qp": 5400,
+        "drop": [
+            {
+                "id": 6520,
+                "name": "血の涙石",
+                "type": "Item",
+                "dropPriority": 8402
+            },
+            {
+                "id": 6527,
+                "name": "万死の毒針",
+                "type": "Item",
+                "dropPriority": 8202
+            },
+            {
+                "id": 6106,
+                "name": "殺の魔石",
+                "type": "Item",
+                "dropPriority": 6195
+            },
+            {
+                "id": 6006,
+                "name": "殺の輝石",
+                "type": "Item",
+                "dropPriority": 6095
+            },
+            {
+                "id": 7006,
+                "name": "アサシンピース",
+                "type": "Item",
+                "dropPriority": 5195
+            },
+            {
+                "id": 94046503,
+                "name": "疑惑のハチミツ",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94046502,
+                "name": "不気味な薬草",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94046501,
+                "name": "怪しい麦袋",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "大魔女の食材集め 味見級"
+    },
+    {
+        "id": 94046605,
+        "name": "大魔女の食材集め 小盛り級",
+        "place": "",
+        "chapter": "",
+        "qp": 6400,
+        "drop": [
+            {
+                "id": 6539,
+                "name": "暁光炉心",
+                "type": "Item",
+                "dropPriority": 8406
+            },
+            {
+                "id": 6508,
+                "name": "ゴーストランタン",
+                "type": "Item",
+                "dropPriority": 8300
+            },
+            {
+                "id": 6107,
+                "name": "狂の魔石",
+                "type": "Item",
+                "dropPriority": 6194
+            },
+            {
+                "id": 6007,
+                "name": "狂の輝石",
+                "type": "Item",
+                "dropPriority": 6094
+            },
+            {
+                "id": 7107,
+                "name": "バーサーカーモニュメント",
+                "type": "Item",
+                "dropPriority": 5294
+            },
+            {
+                "id": 94046502,
+                "name": "不気味な薬草",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94046501,
+                "name": "怪しい麦袋",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "大魔女の食材集め 小盛り級"
+    },
+    {
+        "id": 94046606,
+        "name": "大魔女の食材集め 中盛り級",
+        "place": "",
+        "chapter": "",
+        "qp": 7400,
+        "drop": [
+            {
+                "id": 6531,
+                "name": "奇奇神酒",
+                "type": "Item",
+                "dropPriority": 8505
+            },
+            {
+                "id": 6534,
+                "name": "励振火薬",
+                "type": "Item",
+                "dropPriority": 8105
+            },
+            {
+                "id": 6202,
+                "name": "弓の秘石",
+                "type": "Item",
+                "dropPriority": 6299
+            },
+            {
+                "id": 6102,
+                "name": "弓の魔石",
+                "type": "Item",
+                "dropPriority": 6199
+            },
+            {
+                "id": 6002,
+                "name": "弓の輝石",
+                "type": "Item",
+                "dropPriority": 6099
+            },
+            {
+                "id": 7102,
+                "name": "アーチャーモニュメント",
+                "type": "Item",
+                "dropPriority": 5299
+            },
+            {
+                "id": 94046503,
+                "name": "疑惑のハチミツ",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94046502,
+                "name": "不気味な薬草",
+                "type": "Item",
+                "dropPriority": 2002
+            }
+        ],
+        "shortname": "大魔女の食材集め 中盛り級"
+    },
+    {
+        "id": 94046607,
+        "name": "大魔女の食材集め 大盛り級",
+        "place": "",
+        "chapter": "",
+        "qp": 8400,
+        "drop": [
+            {
+                "id": 6544,
+                "name": "煌星のカケラ",
+                "type": "Item",
+                "dropPriority": 8508
+            },
+            {
+                "id": 6522,
+                "name": "愚者の鎖",
+                "type": "Item",
+                "dropPriority": 8102
+            },
+            {
+                "id": 6201,
+                "name": "剣の秘石",
+                "type": "Item",
+                "dropPriority": 6300
+            },
+            {
+                "id": 6101,
+                "name": "剣の魔石",
+                "type": "Item",
+                "dropPriority": 6200
+            },
+            {
+                "id": 6001,
+                "name": "剣の輝石",
+                "type": "Item",
+                "dropPriority": 6100
+            },
+            {
+                "id": 7101,
+                "name": "セイバーモニュメント",
+                "type": "Item",
+                "dropPriority": 5300
+            },
+            {
+                "id": 94046503,
+                "name": "疑惑のハチミツ",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94046501,
+                "name": "怪しい麦袋",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "大魔女の食材集め 大盛り級"
+    },
+    {
+        "id": 94046608,
+        "name": "大魔女の食材集め おかわり級",
+        "place": "",
+        "chapter": "",
+        "qp": 9400,
+        "drop": [
+            {
+                "id": 6506,
+                "name": "竜の逆鱗",
+                "type": "Item",
+                "dropPriority": 8501
+            },
+            {
+                "id": 6541,
+                "name": "禍罪の矢尻",
+                "type": "Item",
+                "dropPriority": 8315
+            },
+            {
+                "id": 6205,
+                "name": "術の秘石",
+                "type": "Item",
+                "dropPriority": 6296
+            },
+            {
+                "id": 6105,
+                "name": "術の魔石",
+                "type": "Item",
+                "dropPriority": 6196
+            },
+            {
+                "id": 6005,
+                "name": "術の輝石",
+                "type": "Item",
+                "dropPriority": 6096
+            },
+            {
+                "id": 7105,
+                "name": "キャスターモニュメント",
+                "type": "Item",
+                "dropPriority": 5296
+            },
+            {
+                "id": 94046503,
+                "name": "疑惑のハチミツ",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94046502,
+                "name": "不気味な薬草",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94046501,
+                "name": "怪しい麦袋",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "大魔女の食材集め おかわり級"
+    }
+]

--- a/data/json/valentine2019.json
+++ b/data/json/valentine2019.json
@@ -1,0 +1,504 @@
+[
+    {
+        "id": 94033601,
+        "name": "呪本回収 初級",
+        "place": "",
+        "chapter": "",
+        "qp": 1900,
+        "drop": [
+            {
+                "id": 9403680,
+                "name": "ビューティフル・ドリーマー",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6536,
+                "name": "オーロラ鋼",
+                "type": "Item",
+                "dropPriority": 8313
+            },
+            {
+                "id": 6511,
+                "name": "禁断の頁",
+                "type": "Item",
+                "dropPriority": 8303
+            },
+            {
+                "id": 6104,
+                "name": "騎の魔石",
+                "type": "Item",
+                "dropPriority": 6197
+            },
+            {
+                "id": 6004,
+                "name": "騎の輝石",
+                "type": "Item",
+                "dropPriority": 6097
+            },
+            {
+                "id": 7004,
+                "name": "ライダーピース",
+                "type": "Item",
+                "dropPriority": 5197
+            },
+            {
+                "id": 94033504,
+                "name": "詩詠みポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94033502,
+                "name": "想紡ぎの墨",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94033501,
+                "name": "言記しの紙",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "呪本回収 初級"
+    },
+    {
+        "id": 94033602,
+        "name": "呪本回収 中級",
+        "place": "",
+        "chapter": "",
+        "qp": 2900,
+        "drop": [
+            {
+                "id": 9403680,
+                "name": "ビューティフル・ドリーマー",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6532,
+                "name": "枯淡勾玉",
+                "type": "Item",
+                "dropPriority": 8310
+            },
+            {
+                "id": 6511,
+                "name": "禁断の頁",
+                "type": "Item",
+                "dropPriority": 8303
+            },
+            {
+                "id": 6534,
+                "name": "励振火薬",
+                "type": "Item",
+                "dropPriority": 8105
+            },
+            {
+                "id": 6102,
+                "name": "弓の魔石",
+                "type": "Item",
+                "dropPriority": 6199
+            },
+            {
+                "id": 6002,
+                "name": "弓の輝石",
+                "type": "Item",
+                "dropPriority": 6099
+            },
+            {
+                "id": 7002,
+                "name": "アーチャーピース",
+                "type": "Item",
+                "dropPriority": 5199
+            },
+            {
+                "id": 94033504,
+                "name": "詩詠みポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94033503,
+                "name": "夢綴りの筆",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94033502,
+                "name": "想紡ぎの墨",
+                "type": "Item",
+                "dropPriority": 2002
+            }
+        ],
+        "shortname": "呪本回収 中級"
+    },
+    {
+        "id": 94033603,
+        "name": "呪本回収 上級",
+        "place": "",
+        "chapter": "",
+        "qp": 4400,
+        "drop": [
+            {
+                "id": 9403680,
+                "name": "ビューティフル・ドリーマー",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6538,
+                "name": "閑古鈴",
+                "type": "Item",
+                "dropPriority": 8314
+            },
+            {
+                "id": 6511,
+                "name": "禁断の頁",
+                "type": "Item",
+                "dropPriority": 8303
+            },
+            {
+                "id": 6503,
+                "name": "英雄の証",
+                "type": "Item",
+                "dropPriority": 8100
+            },
+            {
+                "id": 6103,
+                "name": "槍の魔石",
+                "type": "Item",
+                "dropPriority": 6198
+            },
+            {
+                "id": 6003,
+                "name": "槍の輝石",
+                "type": "Item",
+                "dropPriority": 6098
+            },
+            {
+                "id": 7003,
+                "name": "ランサーピース",
+                "type": "Item",
+                "dropPriority": 5198
+            },
+            {
+                "id": 94033504,
+                "name": "詩詠みポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94033503,
+                "name": "夢綴りの筆",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94033501,
+                "name": "言記しの紙",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "呪本回収 上級"
+    },
+    {
+        "id": 94033604,
+        "name": "呪本回収 新書級",
+        "place": "",
+        "chapter": "",
+        "qp": 6400,
+        "drop": [
+            {
+                "id": 9403680,
+                "name": "ビューティフル・ドリーマー",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6520,
+                "name": "血の涙石",
+                "type": "Item",
+                "dropPriority": 8402
+            },
+            {
+                "id": 6536,
+                "name": "オーロラ鋼",
+                "type": "Item",
+                "dropPriority": 8313
+            },
+            {
+                "id": 6514,
+                "name": "ホムンクルスベビー",
+                "type": "Item",
+                "dropPriority": 8304
+            },
+            {
+                "id": 6511,
+                "name": "禁断の頁",
+                "type": "Item",
+                "dropPriority": 8303
+            },
+            {
+                "id": 6101,
+                "name": "剣の魔石",
+                "type": "Item",
+                "dropPriority": 6200
+            },
+            {
+                "id": 6001,
+                "name": "剣の輝石",
+                "type": "Item",
+                "dropPriority": 6100
+            },
+            {
+                "id": 7101,
+                "name": "セイバーモニュメント",
+                "type": "Item",
+                "dropPriority": 5300
+            },
+            {
+                "id": 94033504,
+                "name": "詩詠みポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94033502,
+                "name": "想紡ぎの墨",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94033501,
+                "name": "言記しの紙",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "呪本回収 新書級"
+    },
+    {
+        "id": 94033605,
+        "name": "呪本回収 古書級",
+        "place": "",
+        "chapter": "",
+        "qp": 7400,
+        "drop": [
+            {
+                "id": 9403680,
+                "name": "ビューティフル・ドリーマー",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6528,
+                "name": "原初の産毛",
+                "type": "Item",
+                "dropPriority": 8405
+            },
+            {
+                "id": 6532,
+                "name": "枯淡勾玉",
+                "type": "Item",
+                "dropPriority": 8310
+            },
+            {
+                "id": 6511,
+                "name": "禁断の頁",
+                "type": "Item",
+                "dropPriority": 8303
+            },
+            {
+                "id": 6515,
+                "name": "八連双晶",
+                "type": "Item",
+                "dropPriority": 8301
+            },
+            {
+                "id": 6205,
+                "name": "術の秘石",
+                "type": "Item",
+                "dropPriority": 6296
+            },
+            {
+                "id": 6105,
+                "name": "術の魔石",
+                "type": "Item",
+                "dropPriority": 6196
+            },
+            {
+                "id": 7105,
+                "name": "キャスターモニュメント",
+                "type": "Item",
+                "dropPriority": 5296
+            },
+            {
+                "id": 94033504,
+                "name": "詩詠みポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94033503,
+                "name": "夢綴りの筆",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94033502,
+                "name": "想紡ぎの墨",
+                "type": "Item",
+                "dropPriority": 2002
+            }
+        ],
+        "shortname": "呪本回収 古書級"
+    },
+    {
+        "id": 94033606,
+        "name": "呪本回収 奇書級",
+        "place": "",
+        "chapter": "",
+        "qp": 8400,
+        "drop": [
+            {
+                "id": 9403680,
+                "name": "ビューティフル・ドリーマー",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6518,
+                "name": "精霊根",
+                "type": "Item",
+                "dropPriority": 8502
+            },
+            {
+                "id": 6538,
+                "name": "閑古鈴",
+                "type": "Item",
+                "dropPriority": 8314
+            },
+            {
+                "id": 6537,
+                "name": "巨人の指輪",
+                "type": "Item",
+                "dropPriority": 8312
+            },
+            {
+                "id": 6203,
+                "name": "槍の秘石",
+                "type": "Item",
+                "dropPriority": 6298
+            },
+            {
+                "id": 6103,
+                "name": "槍の魔石",
+                "type": "Item",
+                "dropPriority": 6198
+            },
+            {
+                "id": 7107,
+                "name": "バーサーカーモニュメント",
+                "type": "Item",
+                "dropPriority": 5294
+            },
+            {
+                "id": 94033504,
+                "name": "詩詠みポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94033503,
+                "name": "夢綴りの筆",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94033501,
+                "name": "言記しの紙",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "呪本回収 奇書級"
+    },
+    {
+        "id": 94033607,
+        "name": "呪本回収 禁書級",
+        "place": "",
+        "chapter": "",
+        "qp": 9400,
+        "drop": [
+            {
+                "id": 9403680,
+                "name": "ビューティフル・ドリーマー",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6540,
+                "name": "九十九鏡",
+                "type": "Item",
+                "dropPriority": 8506
+            },
+            {
+                "id": 6536,
+                "name": "オーロラ鋼",
+                "type": "Item",
+                "dropPriority": 8313
+            },
+            {
+                "id": 6533,
+                "name": "宵哭きの鉄杭",
+                "type": "Item",
+                "dropPriority": 8104
+            },
+            {
+                "id": 6206,
+                "name": "殺の秘石",
+                "type": "Item",
+                "dropPriority": 6295
+            },
+            {
+                "id": 6006,
+                "name": "殺の輝石",
+                "type": "Item",
+                "dropPriority": 6095
+            },
+            {
+                "id": 7106,
+                "name": "アサシンモニュメント",
+                "type": "Item",
+                "dropPriority": 5295
+            },
+            {
+                "id": 94033504,
+                "name": "詩詠みポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94033503,
+                "name": "夢綴りの筆",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94033502,
+                "name": "想紡ぎの墨",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94033501,
+                "name": "言記しの紙",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "呪本回収 禁書級"
+    }
+]

--- a/data/json/valentine2020.json
+++ b/data/json/valentine2020.json
@@ -1,0 +1,548 @@
+[
+    {
+        "id": 94046001,
+        "name": "キラキラ草子　初級",
+        "place": "",
+        "chapter": "",
+        "qp": 1900,
+        "drop": [
+            {
+                "id": 9404350,
+                "name": "ニット・ザ・ラブ",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6514,
+                "name": "ホムンクルスベビー",
+                "type": "Item",
+                "dropPriority": 8304
+            },
+            {
+                "id": 6006,
+                "name": "殺の輝石",
+                "type": "Item",
+                "dropPriority": 6095
+            },
+            {
+                "id": 7006,
+                "name": "アサシンピース",
+                "type": "Item",
+                "dropPriority": 5195
+            },
+            {
+                "id": 94045904,
+                "name": "キラキラポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94045902,
+                "name": "集いの手毬",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94045901,
+                "name": "出会いの風車",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "キラキラ草子　初級"
+    },
+    {
+        "id": 94046002,
+        "name": "キラキラ草子　中級",
+        "place": "",
+        "chapter": "",
+        "qp": 2900,
+        "drop": [
+            {
+                "id": 9404350,
+                "name": "ニット・ザ・ラブ",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6515,
+                "name": "八連双晶",
+                "type": "Item",
+                "dropPriority": 8301
+            },
+            {
+                "id": 6003,
+                "name": "槍の輝石",
+                "type": "Item",
+                "dropPriority": 6098
+            },
+            {
+                "id": 7003,
+                "name": "ランサーピース",
+                "type": "Item",
+                "dropPriority": 5198
+            },
+            {
+                "id": 94045904,
+                "name": "キラキラポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94045903,
+                "name": "夜すがらの扇",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94045902,
+                "name": "集いの手毬",
+                "type": "Item",
+                "dropPriority": 2002
+            }
+        ],
+        "shortname": "キラキラ草子　中級"
+    },
+    {
+        "id": 94046003,
+        "name": "キラキラ草子　上級",
+        "place": "",
+        "chapter": "",
+        "qp": 4400,
+        "drop": [
+            {
+                "id": 9404350,
+                "name": "ニット・ザ・ラブ",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6503,
+                "name": "英雄の証",
+                "type": "Item",
+                "dropPriority": 8100
+            },
+            {
+                "id": 6001,
+                "name": "剣の輝石",
+                "type": "Item",
+                "dropPriority": 6100
+            },
+            {
+                "id": 7001,
+                "name": "セイバーピース",
+                "type": "Item",
+                "dropPriority": 5200
+            },
+            {
+                "id": 94045904,
+                "name": "キラキラポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94045903,
+                "name": "夜すがらの扇",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94045901,
+                "name": "出会いの風車",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "キラキラ草子　上級"
+    },
+    {
+        "id": 94046004,
+        "name": "キラキラ草子　超級",
+        "place": "",
+        "chapter": "",
+        "qp": 5400,
+        "drop": [
+            {
+                "id": 9404350,
+                "name": "ニット・ザ・ラブ",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6519,
+                "name": "戦馬の幼角",
+                "type": "Item",
+                "dropPriority": 8401
+            },
+            {
+                "id": 6513,
+                "name": "隕蹄鉄",
+                "type": "Item",
+                "dropPriority": 8305
+            },
+            {
+                "id": 6104,
+                "name": "騎の魔石",
+                "type": "Item",
+                "dropPriority": 6197
+            },
+            {
+                "id": 6004,
+                "name": "騎の輝石",
+                "type": "Item",
+                "dropPriority": 6097
+            },
+            {
+                "id": 7004,
+                "name": "ライダーピース",
+                "type": "Item",
+                "dropPriority": 5197
+            },
+            {
+                "id": 94045904,
+                "name": "キラキラポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94045903,
+                "name": "夜すがらの扇",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94045902,
+                "name": "集いの手毬",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94045901,
+                "name": "出会いの風車",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "キラキラ草子　超級"
+    },
+    {
+        "id": 94046005,
+        "name": "キラキラ草子　春はあげぽよ級",
+        "place": "",
+        "chapter": "",
+        "qp": 6400,
+        "drop": [
+            {
+                "id": 9404350,
+                "name": "ニット・ザ・ラブ",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6521,
+                "name": "黒獣脂",
+                "type": "Item",
+                "dropPriority": 8403
+            },
+            {
+                "id": 6510,
+                "name": "無間の歯車",
+                "type": "Item",
+                "dropPriority": 8302
+            },
+            {
+                "id": 6102,
+                "name": "弓の魔石",
+                "type": "Item",
+                "dropPriority": 6199
+            },
+            {
+                "id": 6002,
+                "name": "弓の輝石",
+                "type": "Item",
+                "dropPriority": 6099
+            },
+            {
+                "id": 7102,
+                "name": "アーチャーモニュメント",
+                "type": "Item",
+                "dropPriority": 5299
+            },
+            {
+                "id": 94045904,
+                "name": "キラキラポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94045902,
+                "name": "集いの手毬",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94045901,
+                "name": "出会いの風車",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "キラキラ草子　春はあげぽよ級"
+    },
+    {
+        "id": 94046006,
+        "name": "キラキラ草子　夏はよきよき級",
+        "place": "",
+        "chapter": "",
+        "qp": 7400,
+        "drop": [
+            {
+                "id": 9404350,
+                "name": "ニット・ザ・ラブ",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6540,
+                "name": "九十九鏡",
+                "type": "Item",
+                "dropPriority": 8506
+            },
+            {
+                "id": 6511,
+                "name": "禁断の頁",
+                "type": "Item",
+                "dropPriority": 8303
+            },
+            {
+                "id": 6206,
+                "name": "殺の秘石",
+                "type": "Item",
+                "dropPriority": 6295
+            },
+            {
+                "id": 6106,
+                "name": "殺の魔石",
+                "type": "Item",
+                "dropPriority": 6195
+            },
+            {
+                "id": 7106,
+                "name": "アサシンモニュメント",
+                "type": "Item",
+                "dropPriority": 5295
+            },
+            {
+                "id": 94045904,
+                "name": "キラキラポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94045903,
+                "name": "夜すがらの扇",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94045902,
+                "name": "集いの手毬",
+                "type": "Item",
+                "dropPriority": 2002
+            }
+        ],
+        "shortname": "キラキラ草子　夏はよきよき級"
+    },
+    {
+        "id": 94046007,
+        "name": "キラキラ草子　秋はばえばえ級",
+        "place": "",
+        "chapter": "",
+        "qp": 8400,
+        "drop": [
+            {
+                "id": 9404350,
+                "name": "ニット・ザ・ラブ",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6518,
+                "name": "精霊根",
+                "type": "Item",
+                "dropPriority": 8502
+            },
+            {
+                "id": 6537,
+                "name": "巨人の指輪",
+                "type": "Item",
+                "dropPriority": 8312
+            },
+            {
+                "id": 6205,
+                "name": "術の秘石",
+                "type": "Item",
+                "dropPriority": 6296
+            },
+            {
+                "id": 6105,
+                "name": "術の魔石",
+                "type": "Item",
+                "dropPriority": 6196
+            },
+            {
+                "id": 7105,
+                "name": "キャスターモニュメント",
+                "type": "Item",
+                "dropPriority": 5296
+            },
+            {
+                "id": 94045904,
+                "name": "キラキラポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94045903,
+                "name": "夜すがらの扇",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94045901,
+                "name": "出会いの風車",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "キラキラ草子　秋はばえばえ級"
+    },
+    {
+        "id": 94046008,
+        "name": "キラキラ草子　冬はつらたん級",
+        "place": "",
+        "chapter": "",
+        "qp": 9400,
+        "drop": [
+            {
+                "id": 9404350,
+                "name": "ニット・ザ・ラブ",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6542,
+                "name": "真理の卵",
+                "type": "Item",
+                "dropPriority": 8507
+            },
+            {
+                "id": 6524,
+                "name": "大騎士勲章",
+                "type": "Item",
+                "dropPriority": 8309
+            },
+            {
+                "id": 6201,
+                "name": "剣の秘石",
+                "type": "Item",
+                "dropPriority": 6300
+            },
+            {
+                "id": 6101,
+                "name": "剣の魔石",
+                "type": "Item",
+                "dropPriority": 6200
+            },
+            {
+                "id": 6107,
+                "name": "狂の魔石",
+                "type": "Item",
+                "dropPriority": 6194
+            },
+            {
+                "id": 7101,
+                "name": "セイバーモニュメント",
+                "type": "Item",
+                "dropPriority": 5300
+            },
+            {
+                "id": 94045904,
+                "name": "キラキラポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            },
+            {
+                "id": 94045903,
+                "name": "夜すがらの扇",
+                "type": "Item",
+                "dropPriority": 2003
+            },
+            {
+                "id": 94045902,
+                "name": "集いの手毬",
+                "type": "Item",
+                "dropPriority": 2002
+            },
+            {
+                "id": 94045901,
+                "name": "出会いの風車",
+                "type": "Item",
+                "dropPriority": 2001
+            }
+        ],
+        "shortname": "キラキラ草子　冬はつらたん級"
+    },
+    {
+        "id": 94046009,
+        "name": "キラキラ草子　時はナウしか級",
+        "place": "",
+        "chapter": "",
+        "qp": 9400,
+        "drop": [
+            {
+                "id": 9404350,
+                "name": "ニット・ザ・ラブ",
+                "type": "Craft Essence",
+                "dropPriority": 9005
+            },
+            {
+                "id": 6505,
+                "name": "虚影の塵",
+                "type": "Item",
+                "dropPriority": 8201
+            },
+            {
+                "id": 6516,
+                "name": "凶骨",
+                "type": "Item",
+                "dropPriority": 8101
+            },
+            {
+                "id": 6107,
+                "name": "狂の魔石",
+                "type": "Item",
+                "dropPriority": 6194
+            },
+            {
+                "id": 6007,
+                "name": "狂の輝石",
+                "type": "Item",
+                "dropPriority": 6094
+            },
+            {
+                "id": 7107,
+                "name": "バーサーカーモニュメント",
+                "type": "Item",
+                "dropPriority": 5294
+            },
+            {
+                "id": 94045904,
+                "name": "キラキラポイント",
+                "type": "Point",
+                "dropPriority": 3004
+            }
+        ],
+        "shortname": "キラキラ草子　時はナウしか級"
+    }
+]

--- a/fgosccalc.py
+++ b/fgosccalc.py
@@ -34,7 +34,8 @@ def make_diff(itemlist1, itemlist2):
         diff = copy.deepcopy(after)
         diff_b = copy.deepcopy(before)
         if before["id"] == ID_UNDROPPED and after["id"] == ID_UNDROPPED:
-            continue
+            diff["dropnum"] = "NaN"
+            tmplist.append(diff)
         elif before["id"] == ID_NO_POSESSION or after["id"] == ID_NO_POSESSION:
             continue
         elif before["id"] == ID_UNDROPPED and after["id"] > 0:
@@ -217,8 +218,14 @@ class DropsDiff:
         pieces = []
         wisdoms = []
 
-        for item in self.item_list:
-            if dropitems.item_type[item["id"]] == "Craft Essence":
+        for i, item in enumerate(self.item_list):
+            if item["id"] == ID_UNDROPPED:
+                print("check")
+                if len(self.questdrops) > 0:
+                    item_id = [k for k, v in dropitems.item_name.items() if v == self.questdrops[i]][0]
+                    if dropitems.item_type[item_id] == "Craft Essence":
+                        craft_essence.append({"name":out_name(item_id, dropitems), "dropnum":0})                
+            elif dropitems.item_type[item["id"]] == "Craft Essence":
                 craft_essence.append({"name":out_name(item["id"], dropitems), "dropnum":item["dropnum"]})
             elif ID_STANDARD_ITEM_MIN <= item["id"] <= ID_STANDARD_ITEM_MAX:
                 materials.append({"name":out_name(item["id"], dropitems), "dropnum":item["dropnum"]})

--- a/hash_drop.json
+++ b/hash_drop.json
@@ -406,6 +406,7 @@
         "type": "Craft Essence",
         "rarity": 5,
         "name": "ビューティフル・ドリーマー",
+        "shortname": "礼装",
         "phash": "ba376d42d90a0152",
         "dropPriority": 9005
     },
@@ -492,6 +493,7 @@
         "type": "Craft Essence",
         "rarity": 5,
         "name": "ニット・ザ・ラブ",
+        "shortname": "礼装",
         "phash": "cfcc6cfafe69a7fa",
         "dropPriority": 9005
     },
@@ -1704,7 +1706,9 @@
         "rarity": 2,
         "phash": "3c208bda71764c8c",
         "name": "キラキラポイント",
-        "dropPriority": 3004
+        "shortname": "ポイント",
+        "dropPriority": 3004,
+        "phash_battle": "9ec16938e6c6f894"
     },
     {
         "id": 94043005,
@@ -1731,7 +1735,9 @@
         "rarity": 2,
         "phash": "9e0849584990cc05",
         "name": "詩詠みポイント",
-        "dropPriority": 3004
+        "shortname": "ポイント",
+        "dropPriority": 3004,
+        "phash_battle": "dea52918c6381986"
     },
     {
         "id": 94032207,
@@ -1798,7 +1804,8 @@
         "rarity": 2,
         "phash": "fcc9871669f4eb19",
         "name": "ドラクルコイン",
-        "dropPriority": 3004
+        "dropPriority": 3004,
+        "phash_battle": "bc0396e4eb384a14"
     },
     {
         "id": 94020805,
@@ -1806,7 +1813,9 @@
         "rarity": 2,
         "phash": "5628815668b54e39",
         "name": "空中庭園謹製チョコ",
-        "dropPriority": 3004
+        "shortname": "チョコ",
+        "dropPriority": 3004,
+        "phash_battle": "fe01027007098370"
     },
     {
         "id": 94018805,
@@ -1823,7 +1832,8 @@
         "rarity": 2,
         "phash": "1e68a198699c19a4",
         "name": "織田幕府ポイント",
-        "dropPriority": 3005
+        "dropPriority": 3005,
+        "phash_battle": "3ec5213858e62629"
     },
     {
         "id": 94011304,
@@ -1831,7 +1841,8 @@
         "rarity": 2,
         "phash": "3e6a0b9cc8b37204",
         "name": "新選組ポイント",
-        "dropPriority": 3004
+        "dropPriority": 3004,
+        "phash_battle": "5ea12558a618e126"
     },
     {
         "id": 94009005,
@@ -2138,7 +2149,8 @@
         "phash": "d65a2db4c90f4a03",
         "name": "クークーカカオ",
         "shortname": "カカオ",
-        "dropPriority": 2003
+        "dropPriority": 2003,
+        "phash_battle": "5e85dd0983c33333"
     },
     {
         "id": 94020804,
@@ -2147,7 +2159,8 @@
         "phash": "66c1d930479931ce",
         "name": "フエールフレーバー",
         "shortname": "フレーバー",
-        "dropPriority": 2005
+        "dropPriority": 2005,
+        "phash_battle": "266998651a862996"
     },
     {
         "id": 94023303,
@@ -2236,7 +2249,8 @@
         "phash": "df02788e60339ccf",
         "name": "夢綴りの筆",
         "shortname": "筆",
-        "dropPriority": 2003
+        "dropPriority": 2003,
+        "phash_battle": "669bec33dc679862"
     },
     {
         "id": 94034603,
@@ -2245,7 +2259,8 @@
         "phash": "1e93d96c12c829a9",
         "name": "ハーミットシェーカー",
         "shortname": "シェーカー",
-        "dropPriority": 2003
+        "dropPriority": 2003,
+        "phash_battle": "d66924c22d1208d2"
     },
     {
         "id": 94035003,
@@ -2321,7 +2336,8 @@
         "phash": "9c07836c619c4996",
         "name": "夜すがらの扇",
         "shortname": "扇",
-        "dropPriority": 2003
+        "dropPriority": 2003,
+        "phash_battle": "5e83b81c45922390"
     },
     {
         "id": 94046503,
@@ -2330,7 +2346,8 @@
         "phash": "4649a94e0d94dbc3",
         "name": "疑惑のハチミツ",
         "shortname": "ハチミツ",
-        "dropPriority": 2003
+        "dropPriority": 2003,
+        "phash_battle": "a61906d679a69459"
     },
     {
         "id": 94047703,
@@ -2605,7 +2622,8 @@
         "phash": "5f8817f44a1bf966",
         "name": "ミスティックミルク",
         "shortname": "ミルク",
-        "dropPriority": 2002
+        "dropPriority": 2002,
+        "phash_battle": "ee897409b046a946"
     },
     {
         "id": 94023302,
@@ -2686,7 +2704,8 @@
         "phash": "6c12592889a90de9",
         "name": "想紡ぎの墨",
         "shortname": "墨",
-        "dropPriority": 2002
+        "dropPriority": 2002,
+        "phash_battle": "16339dc56d69290a"
     },
     {
         "id": 94034602,
@@ -2695,7 +2714,8 @@
         "phash": "464c893260911a2d",
         "name": "トリッキークロス",
         "shortname": "クロス",
-        "dropPriority": 2002
+        "dropPriority": 2002,
+        "phash_battle": "e64531681a94e466"
     },
     {
         "id": 94035002,
@@ -2733,7 +2753,8 @@
         "phash": "dcc349b15b70923a",
         "name": "ミラクルトランプ",
         "shortname": "トランプ",
-        "dropPriority": 2002
+        "dropPriority": 2002,
+        "phash_battle": "66a1598ad23124c9"
     },
     {
         "id": 94040902,
@@ -2771,7 +2792,8 @@
         "phash": "5e0925520976c294",
         "name": "集いの手毬",
         "shortname": "手毬",
-        "dropPriority": 2002
+        "dropPriority": 2002,
+        "phash_battle": "ea15e1e05a81956b"
     },
     {
         "id": 94046502,
@@ -2780,7 +2802,8 @@
         "phash": "1606f91cc07986f0",
         "name": "不気味な薬草",
         "shortname": "薬草",
-        "dropPriority": 2002
+        "dropPriority": 2002,
+        "phash_battle": "06f9c5619529ad4a"
     },
     {
         "id": 94047702,
@@ -2975,7 +2998,8 @@
         "phash": "d68d29494c369003",
         "name": "ファンシーシュガー",
         "shortname": "シュガー",
-        "dropPriority": 2001
+        "dropPriority": 2001,
+        "phash_battle": "7a05a1b659a31c09"
     },
     {
         "id": 94023301,
@@ -3056,7 +3080,8 @@
         "phash": "76258c910c814209",
         "name": "言記しの紙",
         "shortname": "紙",
-        "dropPriority": 2001
+        "dropPriority": 2001,
+        "phash_battle": "32cf456920301216"
     },
     {
         "id": 94034601,
@@ -3065,7 +3090,8 @@
         "phash": "5603a5c10928190c",
         "name": "バッドコースター",
         "shortname": "コースター",
-        "dropPriority": 2001
+        "dropPriority": 2001,
+        "phash_battle": "fe0561990ca24252"
     },
     {
         "id": 94035001,
@@ -3103,7 +3129,8 @@
         "phash": "dc13071d28602007",
         "name": "ラッキーダイス",
         "shortname": "ダイス",
-        "dropPriority": 2001
+        "dropPriority": 2001,
+        "phash_battle": "fc030dbcb2cb4820"
     },
     {
         "id": 94040901,
@@ -3141,7 +3168,8 @@
         "phash": "561349ada4938434",
         "name": "出会いの風車",
         "shortname": "風車",
-        "dropPriority": 2001
+        "dropPriority": 2001,
+        "phash_battle": "3689a552cab5411a"
     },
     {
         "id": 94046501,
@@ -3150,7 +3178,8 @@
         "phash": "d60d04a369d08112",
         "name": "怪しい麦袋",
         "shortname": "麦袋",
-        "dropPriority": 2001
+        "dropPriority": 2001,
+        "phash_battle": "7a0581294a1416c3"
     },
     {
         "id": 94047701,

--- a/img2str.py
+++ b/img2str.py
@@ -500,14 +500,14 @@ class ScreenShot:
 class Item:
     hasher = cv2.img_hash.PHash_create()
     def __init__(self, img_rgb, img_hsv, img_gray, svm, dropitems, through_item, template, debug=False):
-        if through_item:
-            self.id = ID_NO_POSESSION
-            self.name = "所持数無しアイテム"
-            self.dropnum = 0
-            return
         if self.is_undropped_box(img_hsv):
             self.id = ID_UNDROPPED
             self.name = "未ドロップ"
+            self.dropnum = 0
+            return
+        if through_item:
+            self.id = ID_NO_POSESSION
+            self.name = "所持数無しアイテム"
             self.dropnum = 0
             return
             


### PR DESCRIPTION
1. 現時点で[未復刻イベント一覧](https://gamewith.jp/fgo/article/show/154578)にでているバトルリザルトのスクショが必要になるイベントは「激闘！クラス別サーヴァント戦」を除き収録した
2. クエスト名が判別されていて、かつ周回前後で礼装がドロップしていない場合、礼装NaNではなく礼装0と出力するようにした