### PR TITLE
fix #88

### DIFF
--- a/img2str.py
+++ b/img2str.py
@@ -265,7 +265,7 @@ class ScreenShot:
         """
         直線検出で検出されなかったフチ幅を検出
         """
-        edge_width = 8
+        edge_width = 3
         ## lx = rx = 0
         height, width = img_th.shape[:2]
         target_color = 255 if reverse else 0


### PR DESCRIPTION
#88 の修正

今では所持位置のチェックにより、他で修正が働くため閾値8の設定は誤認識したとき過剰になるため3に変更