### PR TITLE
quest_list がないというエラーに対応

### DIFF
--- a/img2str.py
+++ b/img2str.py
@@ -157,6 +157,7 @@ class ScreenShot:
             self.error = str(e)
             self.itemlist = []
             self.quest_output = ""
+            self.quest_list = []
             return
 
         if debug:


### PR DESCRIPTION
「正しい」戦利品のスクショではないときに quest_list がなくて正常終了しないエラーに対応