### PR TITLE
fix ValueError in ocr_digit()

### DIFF
--- a/dropitemseditor.py
+++ b/dropitemseditor.py
@@ -213,7 +213,6 @@ class DropsDiff:
 
         for i, item in enumerate(self.item_list):
             if item["id"] == ID_UNDROPPED:
-                print("check")
                 if len(self.questdrops) > 0:
                     item_id = [k for k, v in dropitems.item_name.items() if v == self.questdrops[i]][0]
                     if dropitems.item_type[item_id] == "Craft Essence":

--- a/img2str.py
+++ b/img2str.py
@@ -614,6 +614,8 @@ class Item:
             pt = [pt[0] + offset_x, pt[1] + offset_y, pt[2] + offset_x, pt[3] + offset_y]
             pts.append(pt)
         line_lower_white = self.read_item(self.img_gray, pts)
+        if line_lower_white == "":
+            return -1
         return(int(line_lower_white))
 
     def gem_img2id(self, img, gem_dict):


### PR DESCRIPTION
画像で誤認識が発生したときに "" を取得すると ValueError を出して止まってしまう問題を修正
https://twitter.com/modeconverter/status/1293162935439593472
をcalctweet.pyで読み込んだときに発生

```
$ python calctweet.py -u https://twitter.com/modeconverter/status/1293162935439593472
Traceback (most recent call last):
  File "calctweet.py", line 387, in <module>
    get_one_tweet(args, api)
  File "calctweet.py", line 270, in get_one_tweet
    image_items, error_dic = calc_iamge_diff(status, savelocal=args.savelocal, debug=args.debug)
  File "calctweet.py", line 134, in calc_iamge_diff
    sc = img2str.ScreenShot(image, svm, dropitems, debug)
  File "C:\Users\nono_000\Documents\git\dev9\fgosccalc\img2str.py", line 205, in __init__
    item = Item(item_img_rgb, item_img_hsv, item_img_gray, svm,
  File "C:\Users\nono_000\Documents\git\dev9\fgosccalc\img2str.py", line 520, in __init__
    self.dropnum = self.ocr_digit(debug)
  File "C:\Users\nono_000\Documents\git\dev9\fgosccalc\img2str.py", line 617, in ocr_digit
    return(int(line_lower_white))
ValueError: invalid literal for int() with base 10: ''
```