### PR TITLE
ブラウザ拡張により Sentry (全体の動作には非必須) が無効化された場合でもエラーで落ちないようにする。

### DIFF
--- a/static/js/src/report.jsx
+++ b/static/js/src/report.jsx
@@ -1,8 +1,11 @@
 "use strict";
-// ver 20200801-01
-Sentry.init({
-  dsn: "https://c3ee02d195ae440aacd020b5869abfa7@o425638.ingest.sentry.io/5363673",
-});
+// ver 20200913-01
+
+if (typeof Sentry !== 'undefined') {
+  Sentry.init({
+    dsn: "https://c3ee02d195ae440aacd020b5869abfa7@o425638.ingest.sentry.io/5363673",
+  });
+}
 
 // https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/set-up-twitter-for-websites
 window.twttr = (function(d, s, id) {


### PR DESCRIPTION
Sentry はエラーレポート集約サービスで、ロードできなくてもサービスの提供に支障はない。
よって、ライブラリがロードできなかった場合は初期化処理を実行しない。