### PR TITLE
github workflow 修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ jobs:
     - name: "setup python libraries"
       run: pip install -r requirements-gcloud.txt
 
+    - name: "make item directory in advance to avoid OSError when fgosccalc makes it"
+      run: mkdir item
+
     - name: "run pre-deploy process"
       run: make pre-deploy
 


### PR DESCRIPTION
item ディレクトリがない場合にプログラムが自動的に item ディレクトリを作ろうとして (app engine 環境下において) OSError が発生する。デプロイ前に先に item ディレクトリを作っておくことでこれを回避する。