### PR TITLE
Sc merge fix

### DIFF
--- a/dropitemseditor.py
+++ b/dropitemseditor.py
@@ -452,7 +452,6 @@ def merge_list(upper, bottom):
         lower_start = 0
     else:
         lower_start = 12 - (j - b_candidate)
-
     return upper.itemlist + bottom.itemlist[lower_start:]
 
 
@@ -468,17 +467,30 @@ def merge_sc(sc_list):
             continue
         if sc_list[0].itemlist[i]["dropPriority"] > sc_list[1].itemlist[i]["dropPriority"]:
             logger.debug('use sc_list[0] → sc_list[1] on item %s', i)
-            sc_list[0].itemist = merge_list(sc_list[0], sc_list[1])
+            return merge_list(sc_list[0], sc_list[1])
+        else:
+            return merge_list(sc_list[1], sc_list[0])
+
+
+def detect_upper(sc_list):
+    """
+    list内のスクロール上下を決め上のオブジェクトを返す
+    """
+    if len(sc_list) == 1:
+        return sc_list[0]
+
+    for i in range(len(sc_list[0].itemlist)):
+        if sc_list[0].itemlist[i]["id"] <= 0 or sc_list[1].itemlist[i]["id"] <= 0:
+            continue
+        if sc_list[0].itemlist[i]["dropPriority"] > sc_list[1].itemlist[i]["dropPriority"]:
             return sc_list[0]
         else:
-            logger.debug('use sc_list[1] → sc_list[0] on item %s', i)
-            sc_list[1].itemlist = merge_list(sc_list[1], sc_list[0])
             return sc_list[1]
 
 
 def detect_missing_item(sc_after, sc_before):
     miss_item = []
-    for after, before in zip(sc_after.itemlist, sc_before.itemlist):
+    for after, before in zip(sc_after, sc_before):
         if after["id"] == before["id"]:
             continue
         elif after["id"] != ID_UNDROPPED and after["id"] != ID_NO_POSESSION:

--- a/fgosccalc.py
+++ b/fgosccalc.py
@@ -21,6 +21,7 @@ from dropitemseditor import (
     get_questinfo,
     make_diff,
     make_owned_diff,
+    detect_upper,
     merge_sc,
     read_owned_ss,
     detect_missing_item
@@ -82,11 +83,14 @@ def main(args):
             logger.error("After File: %s", sc.error)
             exit()
         sc_after.append(sc)
-    sc2 = merge_sc(sc_after)
+    # スクロール上下を決める
+    sc2 = detect_upper(sc_after)
+    # マージしたリストを作る
+    sc2_itemlist = merge_sc(sc_after)
     logger.debug('sc_after0: %s', sc_after[0].itemlist)
     if len(sc_after) == 2:
         logger.debug('sc_after1: %s', sc_after[1].itemlist)
-    logger.debug('sc2: %s', sc2.itemlist)
+    logger.debug('sc2: %s', sc2_itemlist)
 
     sc_before = []
     for i, f in enumerate(args.before):
@@ -97,7 +101,10 @@ def main(args):
             logger.error("Before File: %s", sc.error)
             exit()
         sc_before.append(sc)
-    sc1 = merge_sc(sc_before)
+    # スクロール上下を決める
+    sc1 = detect_upper(sc_before)
+    # マージしたリストを作る
+    sc1_itemlist = merge_sc(sc_before)
 
     logger.debug('sc_before0: %s', sc_before[0].itemlist)
     if len(sc_before) == 2:
@@ -105,7 +112,7 @@ def main(args):
     logger.debug('sc1: %s', sc1.itemlist)
 
     # 足りないアイテムを求める
-    miss_items = detect_missing_item(sc2, sc1)
+    miss_items = detect_missing_item(sc2_itemlist, sc1_itemlist)
  
     if args.owned:
         code, owned_list = read_owned_ss(args.owned, dropitems, svm, miss_items)
@@ -117,9 +124,9 @@ def main(args):
 
     owned_diff = []
     if code == 0:
-        owned_diff = make_owned_diff(sc1.itemlist, sc2.itemlist, owned_list)
+        owned_diff = make_owned_diff(sc1_itemlist, sc2_itemlist, owned_list)
 
-    newdic = make_diff(sc1.itemlist, sc2.itemlist, owned=owned_diff)
+    newdic = make_diff(sc1_itemlist, sc2_itemlist, owned=owned_diff)
 
     questname, droplist = get_questinfo(sc1, sc2)
 

--- a/fgosccalc.py
+++ b/fgosccalc.py
@@ -93,10 +93,10 @@ def main(args):
     logger.debug('sc2: %s', sc2_itemlist)
 
     sc_before = []
-    for i, f in enumerate(args.before):
+    for f in args.before:
         file = Path(f)
         img_rgb = img2str.imread(str(file))
-        sc = img2str.ScreenShotBefore(img_rgb, svm, dropitems, sc_after[i].itemlist)
+        sc = img2str.ScreenShot(img_rgb, svm, dropitems)
         if len(sc.itemlist) == 0:
             logger.error("Before File: %s", sc.error)
             exit()

--- a/main.py
+++ b/main.py
@@ -122,10 +122,10 @@ class ScreenShotBundle:
     def _analyze_before_files(self):
         """ 先に _analyze_after_files() を呼び出しておくこと
         """
-        for i, f in enumerate(self.before_files):
+        for f in self.before_files:
             im = cv2.imdecode(get_np_array(f.file), 1)
             self.before_images.append(im)
-            sc = img2str.ScreenShotBefore(im, self.svm, self.dropitems, self.after_sc_objects[i].itemlist)
+            sc = img2str.ScreenShot(im, self.svm, self.dropitems)
             if len(sc.itemlist) == 0:
                 logger.warning('cannot recognize image')
                 if sc.error:

--- a/main.py
+++ b/main.py
@@ -89,19 +89,19 @@ class ScreenShotBundle:
         self.parse_result = None
 
     def analyze(self):
-        self.after_sc = self._analyze_after_files()
-        self.before_sc = self._analyze_before_files()
+        self.after_sc, self.after_sc_itemlist = self._analyze_after_files()
+        self.before_sc, self.before_sc_itemlist = self._analyze_before_files()
 
-        logger.info('sc before: %s', self.before_sc.itemlist)
-        logger.info('sc after: %s', self.after_sc.itemlist)
+        logger.info('sc before: %s', self.before_sc_itemlist)
+        logger.info('sc after: %s', self.after_sc_itemlist)
 
-        missing_items = dropitemseditor.detect_missing_item(self.after_sc, self.before_sc)
+        missing_items = dropitemseditor.detect_missing_item(self.after_sc_itemlist, self.before_sc_itemlist)
         logger.info('missing items: %s', missing_items)
 
         if self.owned_files:
             _, owned_list = dropitemseditor.read_owned_ss(self.owned_files, self.dropitems, self.svm, missing_items)
             logger.info('owned list: %s', owned_list)
-            self.owned_diff = dropitemseditor.make_owned_diff(self.before_sc.itemlist, self.after_sc.itemlist, owned_list)
+            self.owned_diff = dropitemseditor.make_owned_diff(self.before_sc_itemlist, self.after_sc_itemlist, owned_list)
             logger.info('owned diff: %s', self.owned_diff)
 
         for of in self.owned_files:
@@ -113,8 +113,8 @@ class ScreenShotBundle:
             self.owned_images.append(im)
 
         self.parse_result = dropitemseditor.make_diff(
-            copy.deepcopy(self.before_sc.itemlist),
-            copy.deepcopy(self.after_sc.itemlist),
+            copy.deepcopy(self.before_sc_itemlist),
+            copy.deepcopy(self.after_sc_itemlist),
             owned=self.owned_diff,
         )
         logger.info('parse_result: %s', self.parse_result)
@@ -136,7 +136,7 @@ class ScreenShotBundle:
                 )
                 raise CannotAnalyzeError(message)
             self.before_sc_objects.append(sc)
-        return dropitemseditor.merge_sc(self.before_sc_objects)
+        return dropitemseditor.detect_upper(self.before_sc_objects), dropitemseditor.merge_sc(self.before_sc_objects)
 
     def _analyze_after_files(self):
         for f in self.after_files:
@@ -153,7 +153,7 @@ class ScreenShotBundle:
                 )
                 raise CannotAnalyzeError(message)
             self.after_sc_objects.append(sc)
-        return dropitemseditor.merge_sc(self.after_sc_objects)
+        return dropitemseditor.detect_upper(self.after_sc_objects), dropitemseditor.merge_sc(self.after_sc_objects)
 
     def image_pairs(self):
         return itertools.zip_longest(self.before_images, self.after_images)


### PR DESCRIPTION
・複数ファイル認識時、スクロール上下のファイル認識順が周回前後で異なるとエラーになるバグ修正
周回後のアイテム情報を参考に認識処理を高速化する部分は無効とした
これはヒストグラム計算が遅かった時に導入したもので、今はおそらくそれほど速度は変わらないと思われる

・複数ファイル認識時アイテムがちゃんとマージされてなかった問題を修正