### PR TITLE
Deploy: コンテナイメージのキャッシュの残り方が中途半端な場合にCloud Buildが失敗する問題の回避策。

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: "put an empty file in order to avoid CommandException when 'gsutil rm' runs on an empty directory"
       run: |-
-        touch __emptyfile
+        touch __emptyfile__
         gsutil cp __emptyfile__ gs://asia.artifacts.fgosccalc.appspot.com/containers/images/
 
     - name: "clean cache data"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,9 @@ jobs:
     - name: "setup gcloud"
       uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       with:
-        credentials: ${{ secrets.GCLOUD_AUTH }}
+        project_id: fgosccalc
+        service_account_key: ${{ secrets.GCLOUD_AUTH }}
+        export_default_credentials: true
 
     - name: "put an empty file in order to avoid CommandException when 'gsutil rm' runs on an empty directory"
       run: |-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,20 @@ jobs:
         mkdir item
         touch item/.keepdir
 
+    - name: "setup gcloud"
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      with:
+        credentials: ${{ secrets.GCLOUD_AUTH }}
+
+    - name: "put an empty file in order to avoid CommandException when 'gsutil rm' runs on an empty directory"
+      run: |-
+        touch __emptyfile
+        gsutil cp __emptyfile__ gs://asia.artifacts.fgosccalc.appspot.com/containers/images/
+
+    - name: "clean cache data"
+      run: |-
+        gsutil -m rm -r gs://asia.artifacts.fgosccalc.appspot.com/containers/images/
+
     - name: "run pre-deploy process"
       run: make pre-deploy
 


### PR DESCRIPTION
Cloud Build に入る前に、Cloud Storage 上のコンテナイメージが置かれるディレクトリを cleanup する。