### PR TITLE
デプロイ先が複数になったので、わかりやすいように旧デプロイの名前を変える。

### DIFF
--- a/.github/workflows/appengine.yml
+++ b/.github/workflows/appengine.yml
@@ -1,4 +1,4 @@
-name: deploy
+name: Deploy To App Engine
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
`deploy` -> `Deploy To App Engine`