### PR TITLE
Tweet URL の固定をやめる。

### DIFF
--- a/static/js/src/report.jsx
+++ b/static/js/src/report.jsx
@@ -26,7 +26,7 @@ window.twttr = (function(d, s, id) {
 }(document, "script", "twitter-wjs"));
 
 const defaultQuestName = '(クエスト名)'
-const tweetURL = 'https://fgosccalc.appspot.com'
+const tweetURL = ''
 
 class TableLine extends React.Component {
   constructor(props) {


### PR DESCRIPTION
以前 #70 で Tweet に埋め込む URL を固定するようにしたが、完全移行が達成された現在、その意義はなくなっている。一方で、最新環境である Cloud Run 環境からの投稿であっても fgosccalc.appspot.com が挿入されるという問題が生じている。
Tweet URL を固定しないことで、それぞれの実行環境のドメインが挿入されるようになることを期待する。