### PR TITLE
デプロイ時に、同時に古い世代の cloud run revision および container image を削除する。

### DIFF
--- a/.github/workflows/cloudrun_prod.yml
+++ b/.github/workflows/cloudrun_prod.yml
@@ -71,13 +71,13 @@ jobs:
           --service $SERVICE_NAME \
           --region $RUN_REGION \
           | tail -n +7 \
-          | awk '{ print $2 }' \
-          | xargs -I {} gcloud run revisions delete {} --region asia-northeast1 --quiet
+          | awk '{{ print $2 }}' \
+          | xargs -I % gcloud run revisions delete % --region asia-northeast1 --quiet
 
     - name: Delete old container images
       run: |-
         gcloud container images list-tags gcr.io/$PROJECT_ID/$SERVICE_NAME \
           | tail -n +7 \
-          | awk '{ print $1 }' \
-          | xargs -I {} gcloud container images delete \
-          gcr.io/$PROJECT_ID/$SERVICE_NAME@sha256:{} --quiet --force-delete-tags
+          | awk '{{ print $1 }}' \
+          | xargs -I % gcloud container images delete \
+          gcr.io/$PROJECT_ID/$SERVICE_NAME@sha256:% --quiet --force-delete-tags

--- a/.github/workflows/cloudrun_prod.yml
+++ b/.github/workflows/cloudrun_prod.yml
@@ -63,3 +63,21 @@ jobs:
           --image "gcr.io/$PROJECT_ID/$SERVICE_NAME:$GITHUB_SHA" \
           --platform "managed" \
           --allow-unauthenticated
+
+    # Delete old revisions and container images in order to reduce the storage usage
+    - name: Delete old revisions
+      run: |-
+        gcloud run revisions list \
+          --service $SERVICE_NAME \
+          --region $RUN_REGION \
+          | tail -n +7 \
+          | awk '{ print $2 }' \
+          | xargs -I {} gcloud run revisions delete {} --region asia-northeast1 --quiet
+
+    - name: Delete old container images
+      run: |-
+        gcloud container images list-tags gcr.io/$PROJECT_ID/$SERVICE_NAME \
+          | tail -n +7 \
+          | awk '{ print $1 }' \
+          | xargs -I {} gcloud container images delete \
+          gcr.io/$PROJECT_ID/$SERVICE_NAME@sha256:{} --quiet --force-delete-tags

--- a/.github/workflows/cloudrun_stg.yml
+++ b/.github/workflows/cloudrun_stg.yml
@@ -71,13 +71,13 @@ jobs:
           --service $SERVICE_NAME \
           --region $RUN_REGION \
           | tail -n +5 \
-          | awk '{ print $2 }' \
-          | xargs -I {} gcloud run revisions delete {} --region asia-northeast1 --quiet
+          | awk '{{ print $2 }}' \
+          | xargs -I % gcloud run revisions delete % --region asia-northeast1 --quiet
 
     - name: Delete old container images
       run: |-
         gcloud container images list-tags gcr.io/$PROJECT_ID/$SERVICE_NAME \
           | tail -n +5 \
-          | awk '{ print $1 }' \
-          | xargs -I {} gcloud container images delete \
-          gcr.io/$PROJECT_ID/$SERVICE_NAME@sha256:{} --quiet --force-delete-tags
+          | awk '{{ print $1 }}' \
+          | xargs -I % gcloud container images delete \
+          gcr.io/$PROJECT_ID/$SERVICE_NAME@sha256:% --quiet --force-delete-tags

--- a/.github/workflows/cloudrun_stg.yml
+++ b/.github/workflows/cloudrun_stg.yml
@@ -63,3 +63,21 @@ jobs:
           --image "gcr.io/$PROJECT_ID/$SERVICE_NAME:$GITHUB_SHA" \
           --platform "managed" \
           --allow-unauthenticated
+
+    # Delete old revisions and container images in order to reduce the storage usage
+    - name: Delete old revisions
+      run: |-
+        gcloud run revisions list \
+          --service $SERVICE_NAME \
+          --region $RUN_REGION \
+          | tail -n +5 \
+          | awk '{ print $2 }' \
+          | xargs -I {} gcloud run revisions delete {} --region asia-northeast1 --quiet
+
+    - name: Delete old container images
+      run: |-
+        gcloud container images list-tags gcr.io/$PROJECT_ID/$SERVICE_NAME \
+          | tail -n +5 \
+          | awk '{ print $1 }' \
+          | xargs -I {} gcloud container images delete \
+          gcr.io/$PROJECT_ID/$SERVICE_NAME@sha256:{} --quiet --force-delete-tags


### PR DESCRIPTION
残す世代を一定数に保つことで Cloud storage の容量圧迫を防止する。