### PR TITLE
item画像のlocalからの読み込みをしないように

### DIFF
--- a/img2str.py
+++ b/img2str.py
@@ -119,7 +119,7 @@ class DropItems:
 
     def __init__(self, storage=defaultItemStorage):
         self.storage = storage
-        self.calc_dist_local()
+        # self.calc_dist_local()
 
     def calc_dist_local(self):
         """


### PR DESCRIPTION
現在のWEB版の仕様では、立ち上がったコンテナを他の人も使いまわすので他人が作った認識できないアイテムが影響しておかしなことがおこるためほとんど使用していないlocalからの読み込み機能を停止する