### PR TITLE
update deploy actions

### DIFF
--- a/.github/workflows/cloudrun_prod.yml
+++ b/.github/workflows/cloudrun_prod.yml
@@ -29,6 +29,9 @@ jobs:
   setup-build-deploy:
     name: Deploy to Cloud Run (prod)
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
     - name: Checkout
@@ -40,29 +43,30 @@ jobs:
       run: |-
         git log -1 > static/version
 
-    # Setup gcloud CLI
-    - uses: google-github-actions/setup-gcloud@v0
+    # https://github.com/google-github-actions/setup-gcloud#authorization
+    - name: Google Cloud Authorization
+      id: auth
+      uses: google-github-actions/auth@v0
       with:
-        project_id: fgosccalc
-        service_account_key: ${{ secrets.GCLOUD_AUTH }}
-        export_default_credentials: true
+        workload_identity_provider: '${{ secrets.GCLOUD_WORKLOAD_IDENTITY_PROVIDER }}'
+        service_account: '${{ secrets.GCLOUD_SERVICE_ACCOUNT }}'
 
-    # Build and push image to Google Container Registry
-    - name: Build
+    - name: Setup Cloud SDK
+      uses: google-github-actions/setup-gcloud@v0
+
+    - name: Build and push the image to Google Container Registry
       run: |-
         gcloud builds submit \
           --quiet \
           --tag "gcr.io/$PROJECT_ID/$SERVICE_NAME:$GITHUB_SHA"
 
-    # Deploy image to Cloud Run
-    - name: Deploy
+    - name: Deploy to Cloud Run
       id: deploy
       uses: google-github-actions/deploy-cloudrun@v0
       with:
         service: ${{ env.SERVICE_NAME }}
         region: ${{ env.RUN_REGION }}
         image: gcr.io/${{ env.PROJECT_ID }}/${{ env.SERVICE_NAME }}:${{ github.sha }}
-        credentials: ${{ secrets.GCLOUD_AUTH }}
 
     # Delete old revisions and container images in order to reduce the storage usage
     - name: Delete old revisions
@@ -70,14 +74,14 @@ jobs:
         gcloud run revisions list \
           --service $SERVICE_NAME \
           --region $RUN_REGION \
-          | tail -n +7 \
+          | tail -n +5 \
           | awk '{{ print $2 }}' \
           | xargs -I % gcloud run revisions delete % --region asia-northeast1 --quiet
 
     - name: Delete old container images
       run: |-
         gcloud container images list-tags gcr.io/$PROJECT_ID/$SERVICE_NAME \
-          | tail -n +7 \
+          | tail -n +5 \
           | awk '{{ print $1 }}' \
           | xargs -I % gcloud container images delete \
           gcr.io/$PROJECT_ID/$SERVICE_NAME@sha256:% --quiet --force-delete-tags

--- a/.github/workflows/cloudrun_prod.yml
+++ b/.github/workflows/cloudrun_prod.yml
@@ -41,7 +41,7 @@ jobs:
         git log -1 > static/version
 
     # Setup gcloud CLI
-    - uses: google-github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: fgosccalc
         service_account_key: ${{ secrets.GCLOUD_AUTH }}
@@ -57,7 +57,7 @@ jobs:
     # Deploy image to Cloud Run
     - name: Deploy
       id: deploy
-      uses: google-github-actions/deploy-cloudrun@main
+      uses: google-github-actions/deploy-cloudrun@v0
       with:
         service: ${{ env.SERVICE_NAME }}
         region: ${{ env.RUN_REGION }}

--- a/.github/workflows/cloudrun_stg.yml
+++ b/.github/workflows/cloudrun_stg.yml
@@ -29,6 +29,9 @@ jobs:
   setup-build-deploy:
     name: Deploy to Cloud Run (stg)
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
     - name: Checkout
@@ -40,29 +43,30 @@ jobs:
       run: |-
         git log -1 > static/version
 
-    # Setup gcloud CLI
-    - uses: google-github-actions/setup-gcloud@v0
+    # https://github.com/google-github-actions/setup-gcloud#authorization
+    - name: Google Cloud Authorization
+      id: auth
+      uses: google-github-actions/auth@v0
       with:
-        project_id: fgosccalc
-        service_account_key: ${{ secrets.GCLOUD_AUTH }}
-        export_default_credentials: true
+        workload_identity_provider: '${{ secrets.GCLOUD_WORKLOAD_IDENTITY_PROVIDER }}'
+        service_account: '${{ secrets.GCLOUD_SERVICE_ACCOUNT }}'
 
-    # Build and push image to Google Container Registry
-    - name: Build
+    - name: Setup Cloud SDK
+      uses: google-github-actions/setup-gcloud@v0
+
+    - name: Build and push the image to Google Container Registry
       run: |-
         gcloud builds submit \
           --quiet \
           --tag "gcr.io/$PROJECT_ID/$SERVICE_NAME:$GITHUB_SHA"
 
-    # Deploy image to Cloud Run
-    - name: Deploy
+    - name: Deploy to Cloud Run
       id: deploy
       uses: google-github-actions/deploy-cloudrun@v0
       with:
         service: ${{ env.SERVICE_NAME }}
         region: ${{ env.RUN_REGION }}
         image: gcr.io/${{ env.PROJECT_ID }}/${{ env.SERVICE_NAME }}:${{ github.sha }}
-        credentials: ${{ secrets.GCLOUD_AUTH }}
 
     # Delete old revisions and container images in order to reduce the storage usage
     - name: Delete old revisions

--- a/.github/workflows/cloudrun_stg.yml
+++ b/.github/workflows/cloudrun_stg.yml
@@ -41,7 +41,7 @@ jobs:
         git log -1 > static/version
 
     # Setup gcloud CLI
-    - uses: google-github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@v0
       with:
         project_id: fgosccalc
         service_account_key: ${{ secrets.GCLOUD_AUTH }}
@@ -57,7 +57,7 @@ jobs:
     # Deploy image to Cloud Run
     - name: Deploy
       id: deploy
-      uses: google-github-actions/deploy-cloudrun@main
+      uses: google-github-actions/deploy-cloudrun@v0
       with:
         service: ${{ env.SERVICE_NAME }}
         region: ${{ env.RUN_REGION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM nikolaik/python-nodejs:python3.8-nodejs14-slim
+FROM nikolaik/python-nodejs:python3.8-nodejs16-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
-    libopencv-core-dev \
-    libglib2.0-0 \
-    libgl1-mesa-glx \
-    # for SVM
-    libsm6 libxrender1 libxext-dev 
+RUN apt-get update \
+    && apt-get install -y \
+        libopencv-core-dev \
+        libglib2.0-0 \
+        libgl1-mesa-glx \
+        # for SVM
+        libsm6 libxrender1 libxext-dev \
+    && apt-get autoremove \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY requirements-docker.txt ./
 RUN pip install -r requirements-docker.txt


### PR DESCRIPTION
いくつか warnings が出ていたので、それに従い必要な修正を実施。

- 依存する actions のリビジョンを `@master` `@main` (unstable) でなく `@v0` (stable) にする
- gcloud の認証を Service Account Key ではなく Workload Identity Federation にする
  - https://github.com/google-github-actions/setup-gcloud#workload-identity-federation-preferred