### PR TITLE
先頭行のアイテムが !逆鱗 のように ! で開始する場合に最終出力が正しく出ない不具合を修正。

### DIFF
--- a/static/js/src/report.jsx
+++ b/static/js/src/report.jsx
@@ -1,5 +1,5 @@
 "use strict";
-// ver 20210913-1
+// ver 20220519-1
 
 if (typeof Sentry !== 'undefined') {
   Sentry.init({
@@ -1052,6 +1052,7 @@ class EditBox extends React.Component {
         .map(line => { return line.material + line.report })
         .join("-")
         .replace(/-\!/g, '\n')
+        .replace(/^!/, '') // 先頭行のアイテムが ! で始まるケースを考慮
 
     let value = `【${questname}】${runcount}周
 ${reportText}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/696577/169301706-c3cbceda-a6f7-4747-a595-19eac0f836db.png)
