### PR TITLE
妖精騎士杯メダルのx3変換は無効にする。

### DIFF
--- a/static/js/src/report.jsx
+++ b/static/js/src/report.jsx
@@ -148,6 +148,10 @@ class ChunkMaterialCountCell extends React.Component {
       "赤茶葉",
       "黄茶葉",
       "緑茶葉",
+      // カルデア妖精騎士杯
+      "金メダル",
+      "銀メダル",
+      "銅メダル",
     ]
   }
 


### PR DESCRIPTION
誤報告予防のため。