### PR TITLE
メダルも x3 変換対象から除外。

### DIFF
--- a/static/js/src/report.jsx
+++ b/static/js/src/report.jsx
@@ -150,6 +150,9 @@ class ChunkMaterialCountCell extends React.Component {
       "緑茶葉",
       // カルデア妖精騎士杯
       "ゼッケン",
+      "金メダル",
+      "銀メダル",
+      "銅メダル",
     ]
   }
 


### PR DESCRIPTION
90++ で x3, x4 の混在が確認されているため。